### PR TITLE
Desafio Técnico Fullstack - João Mota

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,11 @@
-###
+# MongoDB (matches compose.yml)
+MONGO_URI=mongodb://root:root@localhost:37001/?authSource=admin
+MONGO_DB=production
+
+# API
+API_PORT=49026
+# Comma-separated list of allowed CORS origins
+API_CORS_ORIGIN=http://localhost:49025
+
+# Frontend (Next.js needs the NEXT_PUBLIC_ prefix to expose to the browser)
+NEXT_PUBLIC_API_BASE_URL=http://localhost:49026

--- a/DECISOES.md
+++ b/DECISOES.md
@@ -1,0 +1,168 @@
+# Decisões Técnicas
+
+## Como arrancar
+
+```bash
+docker compose up -d   # MongoDB em localhost:37001
+cp .env.example .env   # já com as credenciais do compose.yml
+npm install            # raiz; o npm workspaces apanha tudo
+npm run dev            # arranca API (49026) + Frontend (49025) via Turbo
+```
+
+Abre `http://localhost:49025`.
+
+---
+
+## Visão geral
+
+Monorepo Turbo com dois apps:
+
+- `apps/api` — Fastify (ESM, NodeNext) que expõe `/favorites` e fala com MongoDB.
+- `apps/frontend` — Next.js 15 (App Router, React 19) que consome a API pública da Carris e a nossa API.
+
+A separação é estrita: nada no `frontend` importa de `api`. Optei por **não criar** um `packages/shared` para tipos partilhados — os únicos tipos sobrepostos (`Favorite`, `Line`) são triviais e duplicar 8 linhas é mais barato do que introduzir um workspace adicional só por isso.
+
+---
+
+## Backend
+
+### Driver MongoDB nativo (em vez de Mongoose)
+A schema do favorito tem 3 campos. O Mongoose introduzia uma camada de schema, hidratação de documentos e dependências adicionais sem benefício real. O driver `mongodb` nativo dá-me:
+- Tipagem genérica (`Collection<Favorite>`) suficiente
+- Controlo direto sobre o `unique index` em `line_id`, que materializa o requisito *"cada favorito deve ser um objeto único na base de dados"*
+- Menos peso e zero magia
+
+### Forma do documento
+```ts
+{
+  line_id: string,                  // chave de negócio, com unique index
+  created_at: UnixTimestamp,        // ms desde epoch (Dates.now().unix_timestamp)
+  operational_date: OperationalDate // "yyyyMMdd" (Dates.now().operational_date)
+}
+```
+
+- Apenas guardo `line_id`, **não** o snapshot da linha. A fonte de verdade da linha é a API pública da CM; duplicar nome/cor/etc. levaria a divergência sem necessidade.
+- `created_at` e `operational_date` são derivados via `Dates.now('Europe/Lisbon')` da `@tmlmobilidade/utils` — o requisito menciona explicitamente os dois e a `Dates` é o caminho idiomático.
+- Timezone `Europe/Lisbon` porque a operação CM é em Portugal: a `operational_date` define o "dia de operação" (relevante p.ex. para serviços noturnos que cruzam a meia-noite e ainda contam como o dia anterior). Tipo definido `as const` para o TypeScript aceitar a string como `TimezoneIdentified`.
+- Os tipos `UnixTimestamp` e `OperationalDate` são os branded types exportados por `@tmlmobilidade/types` — a `Dates` já devolve o branded type, por isso a tipagem flui sem casts.
+
+### POST `/favorites` é idempotente
+Uso `updateOne({ line_id }, { $setOnInsert: favorite }, { upsert: true })` em vez de `insertOne`. Razões:
+- Se o utilizador clicar duas vezes na estrela, o segundo POST não levanta `E11000 duplicate key` ao nível da rede.
+- Mantém-se a `created_at` original (não a sobrescreve em re-pedidos).
+- O `unique index` continua a ser a garantia *real* de unicidade ao nível dos dados.
+
+Validei isto no teste: dois POSTs consecutivos de `line_id: "1234"` devolveram exatamente o mesmo `created_at: 1777299477777`.
+
+### Connection-pool singleton
+`db/mongo.ts` mantém um único `MongoClient`. Funções subsequentes pedem a coleção via `favoritesCollection()`. Isto evita conexões por pedido (custo desnecessário em latência) e simplifica o `ensureIndexes()` (corre uma vez no arranque).
+
+### CORS — múltiplas origens e métodos explícitos
+A configuração lê `API_CORS_ORIGIN` como **lista separada por vírgulas** (em vez de uma única origem). Suporta dev local, staging e produção sem código novo.
+
+Tive de declarar **explicitamente** os métodos permitidos:
+```ts
+await app.register(cors, {
+  methods: ['GET', 'POST', 'DELETE'],
+  origin: config.cors_origin,
+});
+```
+Sem isto, o `@fastify/cors` deduzia os métodos a partir das rotas registadas para o caminho do preflight (`/favorites`) e respondia `GET, HEAD, POST` — omitindo o `DELETE` (que vive em `/favorites/:line_id`). Detetei o problema no browser: o preflight devolvia 204 sem `DELETE` no `Access-Control-Allow-Methods`, e a remoção do favorito falhava só em alguns casos. Ser explícito remove a ambiguidade.
+
+### Logger pino-pretty
+Já vinha como dependência. Configurado de forma minimal para output legível em dev.
+
+### Shutdown limpo
+`SIGINT`/`SIGTERM` fecham Fastify e MongoClient antes de sair. Não é crítico em dev, mas é boa higiene e cabe em 6 linhas.
+
+### Validação de input
+Validação manual (`typeof line_id !== 'string' || line_id.trim() === ''`) com 400 em caso de falha. Para um endpoint com um campo, montar zod + `@fastify/type-provider-zod` seria desproporcional; com mais 2 endpoints já valeria a pena.
+
+---
+
+## Frontend
+
+### Next.js App Router + componente client único
+`app/page.tsx` é `'use client'` porque consome SWR (hooks). O `layout.tsx` foi mantido **intocável** como pedido — toda a configuração de tema e providers vive lá. O `ThemeContextProvider` da TML já inclui `MantineProvider`, `ModalsProvider` e `Notifications`, por isso o `useToast` funciona sem mais setup.
+
+### SWR para data fetching
+Já estava instalado. Uso para os dois fluxos:
+- `useLines()` → CM API. Configurada com `revalidateIfStale: false` + `revalidateOnFocus: false` porque a lista de linhas muda raramente; cache agressivo poupa requests (são 715 linhas no payload).
+- `useFavorites()` → nossa API. Os toggles fazem `mutate` **otimista** com `rollbackOnError: true` — UX imediato (a estrela enche/esvazia sem esperar a rede), mas se a chamada falhar o estado volta atrás e mostra um toast de erro.
+
+### Componentes da TML usados
+Mais do que o mínimo (1) pedido:
+- `ActionIcon` (variantes `warning` / `muted`) — botão de favorito.
+- `Loader` — estado de loading da lista.
+- `useToast` — feedback de erro nos toggles. **Não é um hook** apesar do nome — é uma instância singleton (`new Toast()`), por isso usa-se directamente como `useToast.error(...)` e não `const t = useToast(); t.error(...)`.
+
+Os ícones de estrela vêm de `@tabler/icons-react` (também já instalado).
+
+### Cor do card = identidade da linha
+Cada linha da CM tem `color` e `text_color` próprios. O `LineCard` usa-os no fundo e texto, replicando a identidade visual oficial. O badge interno **inverte** as cores (fundo = `text_color`, texto = `color`) para destacar o `short_name` com bom contraste em qualquer linha.
+
+### Navegação para o site da CM
+Cada card é um `<a href="https://www.carrismetropolitana.pt/lines/{id}">` (mesma aba, conforme "redirecionar" no enunciado). O `FavoriteButton` faz `event.preventDefault()` + `event.stopPropagation()` para que clicar na estrela não dispare a navegação. URL gerada em `lib/env.ts` para ficar centralizada e fácil de mudar.
+
+### Secção "Favoritas" no topo
+Quando há favoritos, surge uma secção dedicada acima da lista completa — assim o feature de favoritar passa a ter utilidade real (atalho rápido) e não fica só "dois cliques sem consequência visível". Só aparece se houver pelo menos um favorito, para não criar ruído quando está vazia.
+
+### CSS modules
+Sem Tailwind no projeto. CSS modules são suportados out-of-the-box pelo Next, são scoped por ficheiro e compõem bem com os componentes da Mantine (que o `@tmlmobilidade/ui` usa por baixo).
+
+---
+
+## Variáveis de ambiente
+
+```env
+MONGO_URI=mongodb://root:root@localhost:37001/?authSource=admin
+MONGO_DB=production
+API_PORT=49026
+API_CORS_ORIGIN=http://localhost:49025   # podem ser várias separadas por vírgula
+NEXT_PUBLIC_API_BASE_URL=http://localhost:49026
+```
+
+- O `dotenv-run` da raiz carrega `.env` antes do Turbo arrancar, e o Turbo (com `envMode: "loose"` já configurado) propaga para os apps.
+- Porta 49026 escolhida para o backend para simetria com a 49025 do frontend e evitar choque com portas comuns.
+- O prefixo `NEXT_PUBLIC_` é obrigatório para o Next.js expor a variável ao browser.
+
+---
+
+## Verificação end-to-end realizada
+
+Tudo testado contra a stack real (Mongo via Docker + API + frontend):
+
+1. **API + Mongo via curl/mongosh:**
+   - `GET /favorites` em base vazia → `[]`
+   - `POST /favorites { line_id: "1001" }` → 201 com `created_at` e `operational_date: "20260427"`
+   - `POST` repetido para o mesmo `line_id` → mesmo `created_at` (idempotência ✓)
+   - `POST { }` (sem `line_id`) → 400 com mensagem de erro
+   - `GET /favorites` → ordenado por `created_at` desc
+   - `DELETE /favorites/1001` → 204
+   - `DELETE /favorites/1001` (já apagado) → 404
+   - `db.favorites.getIndexes()` → confirmado `unique: true` em `line_id`
+   - Tentar `db.favorites.insertOne({ line_id: "x", … })` duas vezes → rejeitado com erro `11000` (unique constraint ✓)
+
+2. **Frontend no browser (Playwright headless):**
+   - Página renderiza header, subtítulo, e secção "Todas as linhas (715)"
+   - Cards mostram `short_name`, `long_name` truncado com ellipsis, estrela vazia
+   - Cor de fundo de cada card respeita o `color` da linha; texto respeita `text_color`
+   - `useFavorites` mostra banner de erro tratado quando a API não responde
+
+3. **Ciclo completo POST/DELETE através do browser (com CORS real):**
+   - `fetch('http://…/favorites')` antes/depois de POST e DELETE bate com o estado em Mongo
+   - Idempotência confirmada também via browser (`created_at` igual em dois POSTs consecutivos)
+
+4. **Lint + type-check (`npm run lint` na raiz):**
+   - Ambos os packages passam `eslint . && tsc --noEmit`
+
+---
+
+## O que ficou de fora (e porquê)
+
+- **Testes automatizados** — não pedidos; a superfície é pequena e o esforço seria desproporcional. Em produção adicionaria pelo menos um teste de integração para a API com `mongodb-memory-server` e um Playwright básico para o toggle de favorito.
+- **Search/filter na lista de linhas** — não pedido. A secção "Favoritas" no topo dá utilidade real ao feature; um filtro seria uma extensão natural mas fora do âmbito.
+- **Auth/rate-limit** — não pedidos; a app é local.
+- **Validação com zod** — para 1 endpoint com 1 campo, validação manual é suficiente.
+- **Package partilhado de tipos** — overhead injustificado para 2 interfaces.
+- **Variantes de tema dark/light** — `ThemeContextProvider` da TML já dá suporte; a UI funciona nas duas. Não criei um toggle dedicado por não ser pedido.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
 		"@tmlmobilidade/types": "20250625.1612.48",
 		"@tmlmobilidade/utils": "20250625.1612.48",
 		"fastify": "5.2.2",
+		"mongodb": "^6.17.0",
 		"pino-pretty": "13.0.0",
 		"resolve-tspaths": "0.8.23",
 		"tsx": "4.19.3",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,0 +1,16 @@
+function required(name: string): string {
+	const value = process.env[name];
+	if (!value) throw new Error(`Missing required env var: ${name}`);
+	return value;
+}
+
+export const config = {
+	cors_origin: (process.env.API_CORS_ORIGIN ?? 'http://localhost:49025')
+		.split(',')
+		.map(s => s.trim())
+		.filter(Boolean),
+	mongo_db: required('MONGO_DB'),
+	mongo_uri: required('MONGO_URI'),
+	port: Number(process.env.API_PORT ?? 49026),
+	timezone: 'Europe/Lisbon',
+} as const;

--- a/apps/api/src/db/mongo.ts
+++ b/apps/api/src/db/mongo.ts
@@ -1,0 +1,30 @@
+import type { Favorite } from '../types.js';
+
+import { type Collection, MongoClient } from 'mongodb';
+
+import { config } from '../config.js';
+
+let client: MongoClient | null = null;
+
+export async function connectMongo(): Promise<MongoClient> {
+	if (client) return client;
+	client = new MongoClient(config.mongo_uri);
+	await client.connect();
+	await ensureIndexes();
+	return client;
+}
+
+export function favoritesCollection(): Collection<Favorite> {
+	if (!client) throw new Error('Mongo not connected — call connectMongo() first');
+	return client.db(config.mongo_db).collection<Favorite>('favorites');
+}
+
+async function ensureIndexes(): Promise<void> {
+	await favoritesCollection().createIndex({ line_id: 1 }, { unique: true });
+}
+
+export async function disconnectMongo(): Promise<void> {
+	if (!client) return;
+	await client.close();
+	client = null;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,1 +1,40 @@
-/* * */
+import cors from '@fastify/cors';
+import Fastify from 'fastify';
+
+import { config } from './config.js';
+import { connectMongo, disconnectMongo } from './db/mongo.js';
+import { favoritesRoutes } from './routes/favorites.js';
+
+async function main(): Promise<void> {
+	const app = Fastify({
+		logger: {
+			transport: { options: { ignore: 'pid,hostname', translateTime: 'HH:MM:ss' }, target: 'pino-pretty' },
+		},
+	});
+
+	await app.register(cors, {
+		methods: ['GET', 'POST', 'DELETE'],
+		origin: config.cors_origin,
+	});
+
+	await connectMongo();
+
+	app.get('/health', async () => ({ status: 'ok' }));
+	await app.register(favoritesRoutes);
+
+	const shutdown = async (signal: string): Promise<void> => {
+		app.log.info(`Received ${signal}, shutting down`);
+		await app.close();
+		await disconnectMongo();
+		process.exit(0);
+	};
+	process.on('SIGINT', () => void shutdown('SIGINT'));
+	process.on('SIGTERM', () => void shutdown('SIGTERM'));
+
+	await app.listen({ host: '0.0.0.0', port: config.port });
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/apps/api/src/routes/favorites.ts
+++ b/apps/api/src/routes/favorites.ts
@@ -1,0 +1,52 @@
+import type { Favorite } from '../types.js';
+import type { FastifyInstance } from 'fastify';
+
+import { Dates } from '@tmlmobilidade/utils';
+
+import { config } from '../config.js';
+import { favoritesCollection } from '../db/mongo.js';
+
+export async function favoritesRoutes(app: FastifyInstance): Promise<void> {
+	app.get('/favorites', async () => {
+		const docs = await favoritesCollection()
+			.find({}, { projection: { _id: 0 } })
+			.sort({ created_at: -1 })
+			.toArray();
+		return docs;
+	});
+
+	app.post<{ Body: { line_id?: unknown } }>('/favorites', async (request, reply) => {
+		const line_id = request.body?.line_id;
+		if (typeof line_id !== 'string' || line_id.trim() === '') {
+			return reply.code(400).send({ error: 'line_id is required and must be a non-empty string' });
+		}
+
+		const now = Dates.now(config.timezone);
+		const favorite: Favorite = {
+			created_at: now.unix_timestamp,
+			line_id,
+			operational_date: now.operational_date,
+		};
+
+		// Idempotent: if it already exists, keep the original created_at/operational_date
+		// and just return it. Otherwise insert. The unique index on line_id guarantees
+		// a single document per line.
+		await favoritesCollection().updateOne(
+			{ line_id },
+			{ $setOnInsert: favorite },
+			{ upsert: true },
+		);
+
+		const stored = await favoritesCollection().findOne({ line_id }, { projection: { _id: 0 } });
+		return reply.code(201).send(stored);
+	});
+
+	app.delete<{ Params: { line_id: string } }>('/favorites/:line_id', async (request, reply) => {
+		const { line_id } = request.params;
+		const result = await favoritesCollection().deleteOne({ line_id });
+		if (result.deletedCount === 0) {
+			return reply.code(404).send({ error: 'favorite not found' });
+		}
+		return reply.code(204).send();
+	});
+}

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,0 +1,7 @@
+import type { OperationalDate, UnixTimestamp } from '@tmlmobilidade/types';
+
+export interface Favorite {
+	created_at: UnixTimestamp
+	line_id: string
+	operational_date: OperationalDate
+}

--- a/apps/frontend/src/app/page.module.css
+++ b/apps/frontend/src/app/page.module.css
@@ -1,0 +1,47 @@
+.page {
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+	margin: 0 auto;
+	max-width: 1200px;
+	padding: 32px 24px;
+}
+
+.header h1 {
+	font-size: 28px;
+	font-weight: 700;
+	margin: 0 0 8px;
+}
+
+.header p {
+	color: #666;
+	font-size: 14px;
+	margin: 0;
+}
+
+.section {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.sectionTitle {
+	font-size: 18px;
+	font-weight: 600;
+	margin: 0;
+}
+
+.center {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+	padding: 48px 0;
+}
+
+.error {
+	background: #fee;
+	border: 1px solid #fcc;
+	border-radius: 8px;
+	color: #900;
+	padding: 16px;
+}

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,12 +1,55 @@
 'use client';
 
-import { Button } from '@tmlmobilidade/ui';
+import { LinesGrid } from '@/components/lines-grid';
+import { useFavorites } from '@/hooks/use-favorites';
+import { useLines } from '@/hooks/use-lines';
+import { Loader } from '@tmlmobilidade/ui';
+import { useMemo } from 'react';
+
+import styles from './page.module.css';
 
 export default function Page() {
+	const { error: linesError, isLoading: linesLoading, lines } = useLines();
+	const { error: favoritesError, isFavorite } = useFavorites();
+
+	const favoriteLines = useMemo(() => lines.filter(l => isFavorite(l.id)), [lines, isFavorite]);
+
 	return (
-		<div>
-			<Button label="Click Me" onClick={() => alert('Button Clicked!')} />
-			<h1>Welcome to TML Frontend</h1>
-		</div>
+		<main className={styles.page}>
+			<header className={styles.header}>
+				<h1>Linhas — Carris Metropolitana</h1>
+				<p>Marca as tuas linhas favoritas. Clica numa linha para abrir a página no site da CM.</p>
+			</header>
+
+			{linesError && (
+				<div className={styles.error}>Erro ao carregar as linhas: {String(linesError)}</div>
+			)}
+
+			{favoritesError && (
+				<div className={styles.error}>
+					Erro ao contactar a API de favoritos. Verifica que o backend e o MongoDB estão a correr.
+				</div>
+			)}
+
+			{linesLoading ? (
+				<div className={styles.center}>
+					<Loader visible />
+				</div>
+			) : (
+				<>
+					{favoriteLines.length > 0 && (
+						<section className={styles.section}>
+							<h2 className={styles.sectionTitle}>Favoritas ({favoriteLines.length})</h2>
+							<LinesGrid lines={favoriteLines} />
+						</section>
+					)}
+
+					<section className={styles.section}>
+						<h2 className={styles.sectionTitle}>Todas as linhas ({lines.length})</h2>
+						<LinesGrid emptyMessage="Sem linhas para mostrar." lines={lines} />
+					</section>
+				</>
+			)}
+		</main>
 	);
 }

--- a/apps/frontend/src/components/favorite-button.tsx
+++ b/apps/frontend/src/components/favorite-button.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useFavorites } from '@/hooks/use-favorites';
+import { IconStar, IconStarFilled } from '@tabler/icons-react';
+import { ActionIcon, useToast } from '@tmlmobilidade/ui';
+
+interface Props {
+	line_id: string
+}
+
+export function FavoriteButton({ line_id }: Props) {
+	const { isFavorite, toggle } = useFavorites();
+	const favorited = isFavorite(line_id);
+
+	const handleClick = async (event: React.MouseEvent) => {
+		event.preventDefault();
+		event.stopPropagation();
+		try {
+			await toggle(line_id);
+		}
+		catch {
+			useToast.error({ message: 'Não foi possível atualizar o favorito.', title: 'Erro' });
+		}
+	};
+
+	return (
+		<ActionIcon
+			aria-label={favorited ? `Remover linha ${line_id} dos favoritos` : `Marcar linha ${line_id} como favorita`}
+			onClick={handleClick}
+			variant={favorited ? 'warning' : 'muted'}
+		>
+			{favorited ? <IconStarFilled size={20} /> : <IconStar size={20} />}
+		</ActionIcon>
+	);
+}

--- a/apps/frontend/src/components/line-card.module.css
+++ b/apps/frontend/src/components/line-card.module.css
@@ -1,0 +1,46 @@
+.card {
+	align-items: center;
+	border-radius: 12px;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+	display: flex;
+	gap: 12px;
+	padding: 16px;
+	text-decoration: none;
+	transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.card:hover {
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+	transform: translateY(-2px);
+}
+
+.badge {
+	align-items: center;
+	border-radius: 8px;
+	display: inline-flex;
+	flex-shrink: 0;
+	font-size: 14px;
+	font-weight: 700;
+	height: 44px;
+	justify-content: center;
+	min-width: 64px;
+	padding: 0 10px;
+}
+
+.text {
+	flex: 1;
+	min-width: 0;
+}
+
+.longName {
+	color: #fff;
+	font-size: 13px;
+	line-height: 1.3;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.actions {
+	flex-shrink: 0;
+}

--- a/apps/frontend/src/components/line-card.tsx
+++ b/apps/frontend/src/components/line-card.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { Line } from '@/types';
+
+import { env } from '@/lib/env';
+
+import styles from './line-card.module.css';
+
+import { FavoriteButton } from './favorite-button';
+
+interface Props {
+	line: Line
+}
+
+export function LineCard({ line }: Props) {
+	return (
+		<a
+			className={styles.card}
+			href={env.cm_line_url(line.id)}
+			style={{ backgroundColor: line.color, color: line.text_color }}
+		>
+			<span
+				className={styles.badge}
+				style={{ backgroundColor: line.text_color, color: line.color }}
+			>
+				{line.short_name}
+			</span>
+			<div className={styles.text}>
+				<div className={styles.longName} title={line.long_name}>
+					{line.long_name}
+				</div>
+			</div>
+			<div className={styles.actions}>
+				<FavoriteButton line_id={line.id} />
+			</div>
+		</a>
+	);
+}

--- a/apps/frontend/src/components/lines-grid.module.css
+++ b/apps/frontend/src/components/lines-grid.module.css
@@ -1,0 +1,11 @@
+.grid {
+	display: grid;
+	gap: 12px;
+	grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+}
+
+.empty {
+	color: #888;
+	font-size: 14px;
+	font-style: italic;
+}

--- a/apps/frontend/src/components/lines-grid.tsx
+++ b/apps/frontend/src/components/lines-grid.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import type { Line } from '@/types';
+
+import styles from './lines-grid.module.css';
+
+import { LineCard } from './line-card';
+
+interface Props {
+	emptyMessage?: string
+	lines: Line[]
+}
+
+export function LinesGrid({ emptyMessage, lines }: Props) {
+	if (lines.length === 0 && emptyMessage) {
+		return <p className={styles.empty}>{emptyMessage}</p>;
+	}
+	return (
+		<div className={styles.grid}>
+			{lines.map(line => (
+				<LineCard key={line.id} line={line} />
+			))}
+		</div>
+	);
+}

--- a/apps/frontend/src/hooks/use-favorites.ts
+++ b/apps/frontend/src/hooks/use-favorites.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import type { Favorite } from '@/types';
+
+import { api } from '@/lib/api';
+import { useCallback, useMemo } from 'react';
+import useSWR from 'swr';
+
+const KEY = 'favorites';
+
+export function useFavorites() {
+	const { data, error, isLoading, mutate } = useSWR<Favorite[]>(KEY, () => api.listFavorites());
+
+	const favoriteIds = useMemo(() => new Set((data ?? []).map(f => f.line_id)), [data]);
+
+	const isFavorite = useCallback((line_id: string) => favoriteIds.has(line_id), [favoriteIds]);
+
+	const toggle = useCallback(
+		async (line_id: string) => {
+			const isCurrentlyFavorited = favoriteIds.has(line_id);
+			const optimistic: Favorite[] = isCurrentlyFavorited
+				? (data ?? []).filter(f => f.line_id !== line_id)
+				: [
+					{
+						created_at: Date.now() as Favorite['created_at'],
+						line_id,
+						operational_date: '' as Favorite['operational_date'],
+					},
+					...(data ?? []),
+				];
+
+			await mutate(
+				async () => {
+					if (isCurrentlyFavorited) {
+						await api.removeFavorite(line_id);
+					}
+					else {
+						await api.addFavorite(line_id);
+					}
+					return api.listFavorites();
+				},
+				{ optimisticData: optimistic, revalidate: false, rollbackOnError: true },
+			);
+		},
+		[data, favoriteIds, mutate],
+	);
+
+	return { error, favorites: data ?? [], isFavorite, isLoading, toggle };
+}

--- a/apps/frontend/src/hooks/use-lines.ts
+++ b/apps/frontend/src/hooks/use-lines.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import type { Line } from '@/types';
+
+import useSWR from 'swr';
+
+const LINES_URL = 'https://api.carrismetropolitana.pt/v2/lines';
+
+async function fetchLines(): Promise<Line[]> {
+	const response = await fetch(LINES_URL);
+	if (!response.ok) throw new Error(`Failed to fetch lines: ${response.status}`);
+	return response.json() as Promise<Line[]>;
+}
+
+export function useLines() {
+	const { data, error, isLoading } = useSWR<Line[]>(LINES_URL, fetchLines, {
+		revalidateIfStale: false,
+		revalidateOnFocus: false,
+		revalidateOnReconnect: false,
+	});
+	return { error, isLoading, lines: data ?? [] };
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1,0 +1,23 @@
+import type { Favorite } from '@/types';
+
+import { env } from './env';
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+	const response = await fetch(`${env.api_base_url}${path}`, {
+		headers: { 'Content-Type': 'application/json' },
+		...init,
+	});
+	if (!response.ok) {
+		throw new Error(`API ${response.status} ${response.statusText}`);
+	}
+	if (response.status === 204) return undefined as T;
+	return response.json() as Promise<T>;
+}
+
+export const api = {
+	addFavorite: (line_id: string) =>
+		request<Favorite>('/favorites', { body: JSON.stringify({ line_id }), method: 'POST' }),
+	listFavorites: () => request<Favorite[]>('/favorites'),
+	removeFavorite: (line_id: string) =>
+		request<undefined>(`/favorites/${encodeURIComponent(line_id)}`, { method: 'DELETE' }),
+};

--- a/apps/frontend/src/lib/env.ts
+++ b/apps/frontend/src/lib/env.ts
@@ -1,0 +1,4 @@
+export const env = {
+	api_base_url: process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:49026',
+	cm_line_url: (id: string) => `https://www.carrismetropolitana.pt/lines/${id}`,
+};

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -1,0 +1,15 @@
+import type { OperationalDate, UnixTimestamp } from '@tmlmobilidade/types';
+
+export interface Line {
+	color: string
+	id: string
+	long_name: string
+	short_name: string
+	text_color: string
+}
+
+export interface Favorite {
+	created_at: UnixTimestamp
+	line_id: string
+	operational_date: OperationalDate
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"@tmlmobilidade/types": "20250625.1612.48",
 				"@tmlmobilidade/utils": "20250625.1612.48",
 				"fastify": "5.2.2",
+				"mongodb": "^6.17.0",
 				"pino-pretty": "13.0.0",
 				"resolve-tspaths": "0.8.23",
 				"tsx": "4.19.3",


### PR DESCRIPTION
## Resumo

Mini-app fullstack para listar e favoritar linhas da Carris Metropolitana.

- **Frontend** (`apps/frontend`): Next.js 15 (App Router) consome a API pública da CM (`/v2/lines`), apresenta as linhas em grelha respeitando as cores oficiais, permite favoritar/desfavoritar (toggle otimista com SWR), e cada card abre `carrismetropolitana.pt/lines/{id}`. Usa `Loader`, `ActionIcon` e `useToast` do `@tmlmobilidade/ui`.
- **API** (`apps/api`): Fastify + driver MongoDB nativo, expõe `GET/POST/DELETE /favorites`. POST é idempotente (`updateOne` com `$setOnInsert + upsert`) e a unicidade fica garantida por um `unique index` em `line_id`. `created_at` (UnixTimestamp) e `operational_date` (OperationalDate) gerados via `Dates.now('Europe/Lisbon')` do `@tmlmobilidade/utils`.

Justificações técnicas detalhadas em `DECISOES.md`, incluindo dois bugs reais detectados e resolvidos (CORS preflight a omitir DELETE, idempotência no POST).

## Como correr

```bash
docker compose up -d
cp .env.example .env
npm install
npm run dev
# http://localhost:49025
```

## Test plan

- [ ] `npm run lint` passa em ambos os packages
- [ ] Lista carrega 715 linhas com `Loader` durante o fetch
- [ ] Toggle de estrela persiste em Mongo e sobrevive a reload
- [ ] Seccao Favoritas aparece no topo apos o primeiro favorito
- [ ] Clicar num card abre `carrismetropolitana.pt/lines/{id}`
- [ ] POST repetido para o mesmo `line_id` mantem o `created_at` original
- [ ] DELETE de favorito inexistente devolve 404